### PR TITLE
Allow BigQuery annotation

### DIFF
--- a/redash/query_runner/big_query.py
+++ b/redash/query_runner/big_query.py
@@ -125,10 +125,6 @@ class BigQuery(BaseQueryRunner):
             'secret': ['jsonKeyFile']
         }
 
-    @classmethod
-    def annotate_query(cls):
-        return False
-
     def __init__(self, configuration):
         super(BigQuery, self).__init__(configuration)
 


### PR DESCRIPTION
Enable BigQuery annotation. This will allow us to monitor who the real query submitter.

Not really sure why the query runner's annotation is disabled in the first place. I've tested this change locally and everything works fine.